### PR TITLE
add kafka sasl support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,21 +2,25 @@ class varnishkafka (
   $output_format_type,
   $output_format,
   $output_type,
-  $daemonize          = $::varnishkafka::params::daemonize,
-  $service_name       = $::varnishkafka::params::service_name,
-  $log_syslog         = $::varnishkafka::params::log_syslog,
-  $log_stderr         = $::varnishkafka::params::log_stderr,
-  $log_errors         = $::varnishkafka::params::log_errors,
-  $log_stats_append   = $::varnishkafka::params::log_stats_append,
-  $log_stats_file     = $::varnishkafka::params::log_stats_file,
-  $log_stats_interval = $::varnishkafka::params::log_stats_interval,
-  $kafka_broker_list  = $::varnishkafka::params::kafka_broker_list,
-  $kafka_retries      = $::varnishkafka::params::kafka_retries,
-  $kafka_partition    = $::varnishkafka::params::kafka_partition,
-  $kafka_buffer_len   = $::varnishkafka::params::kafka_buffer_len,
-  $kafka_require_acks = $::varnishkafka::params::kafka_require_acks,
-  $kafka_timeout      = $::varnishkafka::params::kafka_timeout,
-  $kafka_topic        = $::varnishkafka::params::kafka_topic,
+  $daemonize                = $::varnishkafka::params::daemonize,
+  $service_name             = $::varnishkafka::params::service_name,
+  $log_syslog               = $::varnishkafka::params::log_syslog,
+  $log_stderr               = $::varnishkafka::params::log_stderr,
+  $log_errors               = $::varnishkafka::params::log_errors,
+  $log_stats_append         = $::varnishkafka::params::log_stats_append,
+  $log_stats_file           = $::varnishkafka::params::log_stats_file,
+  $log_stats_interval       = $::varnishkafka::params::log_stats_interval,
+  $kafka_broker_list        = $::varnishkafka::params::kafka_broker_list,
+  $kafka_retries            = $::varnishkafka::params::kafka_retries,
+  $kafka_partition          = $::varnishkafka::params::kafka_partition,
+  $kafka_buffer_len         = $::varnishkafka::params::kafka_buffer_len,
+  $kafka_require_acks       = $::varnishkafka::params::kafka_require_acks,
+  $kafka_timeout            = $::varnishkafka::params::kafka_timeout,
+  $kafka_topic              = $::varnishkafka::params::kafka_topic,
+  $kafka_security_protocol  = $::varnishkafka::params::kafka_security_protocol,
+  $kafka_sasl_mechanism     = $::varnishkafka::params::kafka_sasl_mechanism,
+  $kafka_sasl_username      = $::varnishkafka::params::kafka_sasl_username,
+  $kafka_sasl_password      = $::varnishkafka::params::kafka_sasl_password,
 ) inherits varnishkafka::params {
 
   validate_bool($log_syslog)
@@ -34,6 +38,10 @@ class varnishkafka (
   validate_array($kafka_broker_list)
 
   validate_string($service_name)
+  validate_string($kafka_security_protocol)
+  validate_string($kafka_sasl_mechanism)
+  validate_string($kafka_sasl_username)
+  validate_string($kafka_sasl_password)
   validate_string($kafka_topic)
   validate_string($log_stats_file)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,18 +1,23 @@
 class varnishkafka::params {
-  $service_name       = 'varnishkafka'
-  $log_syslog         = true
-  $log_stderr         = false
-  $log_errors         = true
-  $log_stats_append   = true
-  $log_stats_file     = '/var/run/varnishkafka.stats.json'
-  $log_stats_interval = 60
-  $kafka_broker_list  = [ 'localhost:9092' ]
-  $kafka_retries      = 3
-  $kafka_partition    = -1
-  $kafka_buffer_len   = 1000000
-  $kafka_require_acks = true
-  $kafka_timeout      = 60000
-  $kafka_topic        = 'logs'
+  $service_name             = 'varnishkafka'
+  $log_syslog               = true
+  $log_stderr               = false
+  $log_errors               = true
+  $log_stats_append         = true
+  $log_stats_file           = '/var/run/varnishkafka.stats.json'
+  $log_stats_interval       = 60
+  $kafka_broker_list        = [ 'localhost:9092' ]
+  $kafka_retries            = 3
+  $kafka_partition          = -1
+  $kafka_buffer_len         = 1000000
+  $kafka_require_acks       = true
+  $kafka_timeout            = 60000
+  $kafka_topic              = 'logs'
+  $kafka_security_protocol  = undef
+  $kafka_sasl_mechanism     = undef
+  $kafka_sasl_username      = undef
+  $kafka_sasl_password      = undef
+
   case $::operatingsystem {
     'Debian': {
       case $::operatingsystemmajrelease {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "camptocamp-varnishkafka",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Camptocamp",
   "summary": "Puppet Module to install and configure varnishkafka",
   "license": "Apache-2.0",

--- a/templates/varnishkafka.conf.erb
+++ b/templates/varnishkafka.conf.erb
@@ -16,6 +16,18 @@ kafka.queue.buffering.max.messages = <%= scope.lookupvar('varnishkafka::kafka_bu
 kafka.topic.request.required.acks  = <%= scope.lookupvar('varnishkafka::kafka_require_acks') ? '1' : '0' %>
 kafka.topic.message.timeout.ms     = <%= scope.lookupvar('varnishkafka::kafka_timeout') %>
 kafka.topic                        = <%= scope.lookupvar('varnishkafka::kafka_topic') %>
+<% if scope.lookupvar('varnishkafka::kafka_security_protocol') -%>
+kafka.security.protocol            = <%= scope.lookupvar('varnishkafka::kafka_security_protocol') %>
+<% end -%>
+<% if scope.lookupvar('varnishkafka::kafka_sasl_mechanism') -%>
+kafka.sasl.mechanism               = <%= scope.lookupvar('varnishkafka::kafka_sasl_mechanism') %>
+<% end -%>
+<% if scope.lookupvar('varnishkafka::kafka_sasl_username') -%>
+kafka.sasl.username                = <%= scope.lookupvar('varnishkafka::kafka_sasl_username') %>
+<% end -%>
+<% if scope.lookupvar('varnishkafka::kafka_sasl_password') -%>
+kafka.sasl.password                = <%= scope.lookupvar('varnishkafka::kafka_sasl_password') %>
+<% end -%>
 log.kafka.msg.error                = <%= scope.lookupvar('varnishkafka::log_errors') %>
 log.stderr                         = <%= scope.lookupvar('varnishkafka::log_stderr') %>
 log.syslog                         = <%= scope.lookupvar('varnishkafka::log_syslog') %>


### PR DESCRIPTION
This change allows to add the following parameters to `varnishkafka.conf` :
 * `kafka.security.protocol`
 * `kafka.sasl.mechanism`
 * `kafka.sasl.username`
 * `kafka.sasl.password`